### PR TITLE
Output results as CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased] (beta, main branch content)
 
+- Fix wrong exit code which has to be related to --failon option (default: `error`)
+
 ## [2.12.0] 2023-08-29
 
 - Fix exit code that should be 1 according to --failon value [#71](https://github.com/Force-Config-Control/lightning-flow-scanner-sfdx/issues/71)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "fs-extra": "^11.1.1",
     "glob": "^7.1.7",
     "lightning-flow-scanner-core": "2.23",
+    "papaparse": "^5.4.1",
     "tslib": "^1",
     "xml2js": "^0.4.23"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3279,6 +3279,11 @@ package-hash@^3.0.0:
     lodash.flattendeep "^4.4.0"
     release-zalgo "^1.0.0"
 
+papaparse@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.4.1.tgz#f45c0f871853578bd3a30f92d96fdcfb6ebea127"
+  integrity sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"


### PR DESCRIPTION
--output csv,console(default)
--outputfile: path of CSV file, or default current directory + reports/flow-scanner-results.csv
Fixes https://github.com/Lightning-Flow-Scanner/lightning-flow-scanner-sfdx/issues/74

Example output: 
![image](https://github.com/Lightning-Flow-Scanner/lightning-flow-scanner-sfdx/assets/17500430/7a0e0a8f-f5dc-4d69-90c1-0c8e2376900a)
