### PR TITLE
fix rule names in UnusedVariables in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ When the severity is not provided it will be `error` by default. Other available
     "FlowDescription": {
       "severity": "warning"
     },
-    "UnusedVariables": {
+    "UnusedVariable": {
       "severity": "error"
     }
   }
@@ -140,12 +140,12 @@ Specifying exceptions can be done by flow, rule and result(s), as shown in the f
 {
   "exceptions": {
     "AssignTaskOwner": {
-      "UnusedVariables": [
+      "UnusedVariable": [
         "somecount"
       ]
     },
     "GetAccounts":{
-      "UnusedVariables": [
+      "UnusedVariable": [
         "incvar"
       ]
     }


### PR DESCRIPTION
First of all, our team has always been very helpful with lightning-flow-scanner. Thanks again.

In this case, I found a minor fix in README.md and submitted a pull request.
The phenomenon is,
I am using "UnusedVariables" in README.md.
would result in the following error.

```json
{
    "status": 1,
    "name": "Error",
    "message": "Class type of 'UnusedVariables' is not in the store",
    "exitCode": 1,
    "commandName": "scan",
    "stack": "Error: Class type of 'UnusedVariables' is not in the store\n  
```

## cause

"UnusedVariable" is defined in[ lightning-flow-scanner-core](https://github.com/Lightning-Flow-Scanner/lightning-flow-scanner-core#unused-variable).
It is slightly different from README.md in this repository.

Therefore, "UnusedVariables" in README.md has been committed to "UnusedVariable".
