### PR TITLE
Automate tests & release from GitHub Actions

### DIFF
--- a/.github/workflows/deploy-ALPHA.yml
+++ b/.github/workflows/deploy-ALPHA.yml
@@ -1,0 +1,47 @@
+---
+#
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+#
+
+#######################################
+# Start the job on all push to master #
+#######################################
+name: "Build & Deploy - ALPHA"
+on:
+  push:
+    branches:
+      - "alpha"
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.ref_name }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+###############
+# Set the Job #
+###############
+jobs:
+  deploy:
+    name: Deploy alpha
+    runs-on: ubuntu-latest
+    permissions: read-all
+    environment:
+      name: alpha
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: "https://registry.npmjs.org"
+          always-auth: true
+          # Defaults to the user or organization that owns the workflow file
+          scope: "rubenhalman"
+      - run: yarn
+      - run: yarn config set version-git-tag false && tsc -b
+      - run: ALPHAID=$(date '+%Y%m%d%H%M') && yarn version --prepatch --preid="alpha$ALPHAID"
+      - run: yarn config set network-timeout 300000 && yarn publish --tag alpha
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/deploy-BETA.yml
+++ b/.github/workflows/deploy-BETA.yml
@@ -1,0 +1,48 @@
+---
+#
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+#
+
+#######################################
+# Start the job on all push to master #
+#######################################
+name: "Build & Deploy - BETA"
+on:
+  push:
+    branches:
+      - "main"
+      - "master"
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.ref_name }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+###############
+# Set the Job #
+###############
+jobs:
+  deploy:
+    name: Deploy beta
+    runs-on: ubuntu-latest
+    permissions: read-all
+    environment:
+      name: beta
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: "https://registry.npmjs.org"
+          always-auth: true
+          # Defaults to the user or organization that owns the workflow file
+          scope: "rubenhalman"
+      - run: yarn
+      - run: yarn config set version-git-tag false && tsc -b
+      - run: BETAID=$(date '+%Y%m%d%H%M') && yarn version --prepatch --preid="beta$BETAID"
+      - run: yarn config set network-timeout 300000 && yarn publish --tag beta
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/deploy-RELEASE.yml
+++ b/.github/workflows/deploy-RELEASE.yml
@@ -1,0 +1,43 @@
+---
+#
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+#
+
+#######################################
+# Start the job on all push to master #
+#######################################
+name: "Build & Deploy - RELEASE"
+on:
+  release:
+    # Want to run the automation when a release is created
+    types: ["created"]
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.ref_name }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+###############
+# Set the Job #
+###############
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions: read-all
+    environment:
+      name: release
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: "https://registry.npmjs.org"
+          # Defaults to the user or organization that owns the workflow file
+          scope: "rubenhalman"
+      - run: yarn
+      - run: yarn config set network-timeout 300000 && yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+---
+#
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+#
+
+#######################################
+# Start the job on all push to master #
+#######################################
+name: "Test"
+on:
+  push: # Comment this line to trigger action only on pull-requests (not recommended if you don't pay for GH Actions)
+  pull_request:
+    branches: [master, main]
+
+###############
+# Set the Job #
+###############
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: "https://registry.npmjs.org"
+          # Defaults to the user or organization that owns the workflow file
+          scope: "nvuillam"
+      - run: yarn
+      - run: yarn prepack
+      - run: yarn test
+#      - name: Submitting code coverage to codecov
+#        run: |
+#          ./node_modules/.bin/nyc report --reporter text-lcov > coverage.lcov
+#          curl -s https://codecov.io/bash | bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           # Defaults to the user or organization that owns the workflow file
           scope: "nvuillam"
-      - run: yarn
-      - run: yarn prepack
-      - run: yarn test
-#      - name: Submitting code coverage to codecov
-#        run: |
-#          ./node_modules/.bin/nyc report --reporter text-lcov > coverage.lcov
-#          curl -s https://codecov.io/bash | bash
+      - name: Install dependencies and link
+        run: npm ci && npm link
+      - name: Run tests
+        run: npm run test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fix wrong exit code which has to be related to --failon option (default: `error`)
 - Display severity in human format results
+- Automate Releases via GitHub Actions
+  - From `master` branch: **beta**
+  - From `alpha` branch: **alpha**
+  - When a GitHub release is created: Git tag selected for the release.
+- Run tests during Pull Request checks
 
 ## [2.12.0] 2023-08-29
 


### PR DESCRIPTION
- Automate Releases via GitHub Actions
  - From `master` branch: **beta**
  - From `alpha` branch: **alpha**
  - When a GitHub release is created: Git tag selected for the release.
- Run tests during Pull Request checks

Will require a NPM_TOKEN set to work
