### PR TITLE
fix: flow name was only displaying first character and combining results

### DIFF
--- a/src/commands/flow/scan.ts
+++ b/src/commands/flow/scan.ts
@@ -96,7 +96,7 @@ export default class scan extends SfdxCommand {
       }
       for (const resultKey in resultsByFlow) {
         const matchingScanResult = scanResults.find((res) => {
-          return res.flow.label[0] === resultKey
+          return res.flow.label === resultKey
         });
         this.ux.styledHeader("Flow: " + c.yellow(resultKey) + " " + c.red("(" + resultsByFlow[resultKey].length + " results)"));
         this.ux.log(c.italic('Type: ' + matchingScanResult.flow.type));
@@ -116,7 +116,7 @@ export default class scan extends SfdxCommand {
     for (const severity of ["error","warning","note"]) {
       const severityCounter = this.errorCounters[severity] || 0;
       this.ux.log(`- ${severity}: ${severityCounter}`);
-    }    
+    }
 
     // TODO CALL TO ACTION
     this.ux.log('');
@@ -185,7 +185,7 @@ export default class scan extends SfdxCommand {
   private buildResults(scanResults) {
     const errors = [];
     for (const scanResult of scanResults) {
-      const flowName = scanResult.flow.label[0];
+      const flowName = scanResult.flow.label;
       const flowType = scanResult.flow.type[0];
       for (const ruleResult of scanResult.ruleResults as core.RuleResult[]) {
         const ruleDescription = ruleResult.ruleDefinition.description;


### PR DESCRIPTION
I finally sat down and had some time to start looking over my (many) violations in my org. I quickly realized that the flow scanner wasn't displaying the full name of the flow in the results. 

This led me to another realization, which is a much larger issue. Because only the first character of the label was being retrieved, all flows that began with the same letter were having their results combined!

Before:
![Screenshot 2024-06-12 at 3 50 04 PM](https://github.com/Lightning-Flow-Scanner/lightning-flow-scanner-sfdx/assets/10662184/c1800477-8345-4cff-91c5-4bf6367d7c69)


After:
![Screenshot 2024-06-12 at 3 51 00 PM](https://github.com/Lightning-Flow-Scanner/lightning-flow-scanner-sfdx/assets/10662184/72080f6f-2643-405c-b4a6-ed0a9ed4386c)
![Screenshot 2024-06-12 at 3 52 13 PM](https://github.com/Lightning-Flow-Scanner/lightning-flow-scanner-sfdx/assets/10662184/320e2146-ce1a-4596-8dde-c58e90db0bcc)
