### PR TITLE
chore(core): update core to 4.8.0 trigger order rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,12 @@
         "cosmiconfig": "^9.0.0",
         "fs-extra": "^11.2.0",
         "glob": "^11.0.0",
-        "lightning-flow-scanner-core": "4.7.0",
+        "lightning-flow-scanner-core": "4.8.0",
         "tslib": "^2",
         "xml2js": "^0.6.2"
       },
       "devDependencies": {
-        "@oclif/plugin-help": "^6.2.16",
+        "@oclif/plugin-help": "^6.2.17",
         "@oclif/test": "^4.1.0",
         "@salesforce/dev-config": "^4.3.1",
         "@salesforce/ts-sinon": "^1.4.29",
@@ -2978,9 +2978,9 @@
       }
     },
     "node_modules/@oclif/plugin-help": {
-      "version": "6.2.16",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.16.tgz",
-      "integrity": "sha512-1x/Bm0LebDouDOfsjkOz+6AXqY6gIZ6JmmU/KuF/GnUmowDvj5i3MFlP9uBTiN8UsOUeT9cdLwnc1kmitHWFTg==",
+      "version": "6.2.17",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.17.tgz",
+      "integrity": "sha512-+Z+xC11h+f4SHX1pW5lhoCT+aC0bQABfnRsIs/02gf7dZ1XSfi1I17ZMrrzYCcUNcDJA33guKUQeUK740hXPlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7640,9 +7640,9 @@
       }
     },
     "node_modules/lightning-flow-scanner-core": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lightning-flow-scanner-core/-/lightning-flow-scanner-core-4.7.0.tgz",
-      "integrity": "sha512-KRIoDuppTt5XpGcs3b91qazvT8+LLPfL49gkGO88ZIgNM16xBatfmiFLbvLA7Q6pS71gEAZN5Z70/hSPdOC+7w==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/lightning-flow-scanner-core/-/lightning-flow-scanner-core-4.8.0.tgz",
+      "integrity": "sha512-lSBmOiwKzxZjwy5ij16a6FdzPgyEetU3wCdPml2KpmBZVyrESLU4CS5XXuFFBtWEkE8iJnGUIWhx2tFGb661fg==",
       "license": "MIT",
       "dependencies": {
         "@types/path-browserify": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "cosmiconfig": "^9.0.0",
     "fs-extra": "^11.2.0",
     "glob": "^11.0.0",
-    "lightning-flow-scanner-core": "4.7.0",
+    "lightning-flow-scanner-core": "4.8.0",
     "tslib": "^2",
     "xml2js": "^0.6.2"
   },
   "devDependencies": {
-    "@oclif/plugin-help": "^6.2.16",
+    "@oclif/plugin-help": "^6.2.17",
     "@oclif/test": "^4.1.0",
     "@salesforce/dev-config": "^4.3.1",
     "@salesforce/ts-sinon": "^1.4.29",


### PR DESCRIPTION
New & Changed Rules:
| Rule (Configuration ID) | Description |
|--------------------------|-------------|
| **Same Record Field Updates** ([`SameRecordFieldUpdates`](https://github.com/Lightning-Flow-Scanner/lightning-flow-scanner-core/tree/master/src/main/rules/SameRecordFieldUpdates.ts)) | Much like triggers, before contexts can update the same record by accessing the trigger variables `$Record` without needing to invoke a DML. |
| **Missing Fault Path** ([`MissingFaultPath`](https://github.com/Lightning-Flow-Scanner/lightning-flow-scanner-core/tree/master/src/main/rules/MissingFaultPath.ts)) | At times, a flow may fail to execute a configured operation as intended. By default, the flow displays an error message to the user and notifies the admin who created the flow via email. However, you can customize this behavior by incorporating a Fault Path. |
| **Trigger Order** ([`TriggerOrder`](https://github.com/Lightning-Flow-Scanner/lightning-flow-scanner-core/tree/master/src/main/rules/TriggerOrder.ts)) | Guarantee your flow execution order with the Trigger Order property introduced in Spring '22 |
