### PR TITLE
#183 Azure DevOps build pipeline examples.

### DIFF
--- a/docs/examples/azure-devops/README.md
+++ b/docs/examples/azure-devops/README.md
@@ -1,0 +1,27 @@
+## Azure Pipelines Examples
+
+These samples show two common ways to run the Lightning Flow Scanner from Azure DevOps. Each template installs the Salesforce CLI inside the official `salesforce/cli:latest-slim` container, adds the `lightning-flow-scanner` plugin, executes `sf flow:scan`, and uploads a SARIF report as a build artifact so violations can be reviewed with the SARIF Results Viewer extension.
+
+### Included templates
+
+- `azure-pipelines-flow-FullScan.yml`  
+  Runs the scanner across the entire repo (or the default metadata folder) every time the pipeline triggers. The job is intentionally small: check out the code, ensure the plugin is available, run `sf flow:scan --sarif`, and publish `results.sarif` via `PublishBuildArtifacts@1`. Add additional stages (tests, packaging) by extending this template.
+
+- `azure-pipelines-flow-changedFiles.yml`  
+  Optimizes for pull requests by scanning only files that change relative to a target branch (default `origin/main`). It persists Git credentials so it can `git fetch` and uses a bash step to copy added/modified files into `$(Build.ArtifactStagingDirectory)/diff`. The scanner is then pointed at that folder to shorten runtimes while still producing a SARIF artifact.
+
+### How to use these templates
+
+1. Copy the desired YAML file into your Azure DevOps repo (commonly under `.azure-pipelines/` or at the root).
+2. In Azure DevOps, create a new pipeline and reference the YAML path when prompted.
+3. For the changed-files variant, update the `variables` block if your default branch is not `origin/main`, or if you want to store diffs elsewhere.
+4. (Optional) Install the [SARIF SAST Scans Tab extension](https://marketplace.visualstudio.com/items?itemName=sariftools.scans) so teams can review `results.sarif` directly within the pipeline summary.
+
+### Dependencies and related docs
+
+- **Salesforce CLI**: Provided by the `salesforce/cli:latest-slim` container. If you switch containers/VMs, ensure `sf` is installed and on the `PATH`.  
+- **Lightning Flow Scanner plugin**: Installed via `sf plugins install lightning-flow-scanner`. See the main [Lightning Flow Scanner README](../../../README.md) for configuration options such as custom rule sets.  
+- **Git (changed-files pipeline)**: Requires fetch permissions on the target branch to build the diff. Azure Pipelines handles this automatically when `persistCredentials: true` and `fetchDepth: 1` are set.  
+- **SARIF tooling**: Pipelines emit `CodeAnalysisLogs/results.sarif`. Use Azure DevOps extensions or downstream tooling (GitHub Advanced Security, VS Code SARIF viewer, etc.) to visualize the findings.
+
+Adapt these templates as needed: add caching, integrate test stages, or call other CLI commands before/after the flow scan to match your organization's release process.

--- a/docs/examples/azure-devops/azure-pipelines-flow-FullScan.yml
+++ b/docs/examples/azure-devops/azure-pipelines-flow-FullScan.yml
@@ -1,0 +1,28 @@
+pool:
+  vmImage: 'ubuntu-latest'
+
+# Use the Salesforce-Provided docker image with SF CLI preinstalled
+# https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_docker.htm
+container: salesforce/cli:latest-slim
+
+steps:
+- checkout: self
+
+# Ensure lightning-flow-scanner is installed (pipe "Y" to confirm installation)
+- script: |
+    echo Y | sf plugins install lightning-flow-scanner
+  displayName: 'Ensure lightning-flow-scanner is installed'
+
+# Capture SARIF from stdout → file
+- script: |
+    sf flow:scan --sarif > $(Build.ArtifactStagingDirectory)/results.sarif
+  displayName: Run Flow Scanner (stdout to SARIF)
+
+# Upload SARIF as artifact pipeline (per documentation https://marketplace.visualstudio.com/items?itemName=sariftools.scans)
+- task: PublishBuildArtifacts@1
+ # Flow scanner may report failure when it detects violations. Ignore that and publish artifacts anyway
+  condition: succeededOrFailed()
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/results.sarif'
+    ArtifactName: 'CodeAnalysisLogs'
+    publishLocation: 'Container'

--- a/docs/examples/azure-devops/azure-pipelines-flow-changedFiles.yml
+++ b/docs/examples/azure-devops/azure-pipelines-flow-changedFiles.yml
@@ -1,0 +1,63 @@
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  targetBranch: "origin/main"
+  destinationFolder: "$(Build.ArtifactStagingDirectory)/diff/"
+
+# Use the Salesforce-Provided docker image with SF CLI preinstalled
+# https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_docker.htm
+container: salesforce/cli:latest-slim
+
+steps:
+# Checkout the repository with credentials persisted for git commands
+- checkout: self
+  persistCredentials: true
+  clean: true
+  fetchDepth: 1
+  fetchTags: false
+
+# Ensure lightning-flow-scanner is installed (pipe "Y" to confirm)
+- script: |
+    echo Y | sf plugins install lightning-flow-scanner
+  displayName: 'Ensure lightning-flow-scanner is installed'
+
+# Get added and changed files from the PR and copy them to a directory
+- script: |
+    # Fetch the PRs target branch so that we can compare against it
+    echo "Fetching target branch: $(targetBranch)..."
+    git fetch $targetBranch
+
+    diffFilter="AM" # Added and modified files
+
+    echo "Determining changed files..."
+    # Compute the list of changed files between target and source branches.
+    CHANGED_FILES=$(git diff --name-only --diff-filter=$diffFilter $(targetBranch))
+    echo "Changed files: $CHANGED_FILES"
+
+    # Create the destination directory to store changed files
+    mkdir -p "$(destinationFolder)"
+
+    # Copy each changed file into the directory while preserving the directory structure.
+    for file in $CHANGED_FILES; do
+      if [ -f "$file" ]; then
+        mkdir -p "$(destinationFolder)$(dirname $file)"
+        cp "$file" "$(destinationFolder)$file"
+      fi
+    done
+    echo "Files copied to $(destinationFolder)"
+  displayName: 'Extract Added and Changed Files'
+
+# Scan only the changed files and capture SARIF from stdout → file
+- script: |
+    sf flow:scan -d "$(destinationFolder)" --sarif > $(Build.ArtifactStagingDirectory)/results.sarif
+  displayName: Run Flow Scanner (stdout to SARIF)
+
+# Upload SARIF as artifact pipeline (per documentation https://marketplace.visualstudio.com/items?itemName=sariftools.scans)
+- task: PublishBuildArtifacts@1
+ # Flow scanner may report failure when it detects violations. ignore that and publish artifacts anyway
+  condition: succeededOrFailed()
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/results.sarif'
+    ArtifactName: 'CodeAnalysisLogs'
+    publishLocation: 'Container'


### PR DESCRIPTION
## Summary
- add docs/examples/azure-devops/README.md describing how to use the Azure DevOps pipeline samples, their prerequisites, and recommended extensions
- include azure-pipelines-flow-FullScan.yml for a repo-wide scan job and azure-pipelines-flow-changedFiles.yml to lint only PR deltas, each publishing SARIF artifacts for review

## Testing
documentation and samples only (pipelines not executed in CI)

Closes #183 